### PR TITLE
041123_bhas_update_5_fix_4

### DIFF
--- a/.ebextensions/.config
+++ b/.ebextensions/.config
@@ -2,4 +2,3 @@ option_settings:
   aws:elasticbeanstalk:application:environment:
     STREAMLIT_SERVER_PORT: 80
     STREAMLIT_BROWSER_GATHER_USAGE_STATS: "false"
-    ANOTHER_ENV_VAR: "value"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.6-slim
+FROM python:3.10.13-slim-bullseye
 
 WORKDIR /usr/src/app
 
@@ -12,5 +12,6 @@ RUN python scripts/init_db.py
 RUN python scripts/load_data.py
 
 EXPOSE 8501
+EXPOSE 80
 
 CMD ["streamlit", "run", "app.py"]


### PR DESCRIPTION
* chore(.ebextensions/.config): remove ANOTHER_ENV_VAR from environment variables

* fix(Dockerfile): update base image to python:3.10.13-slim-bullseye
* feat(Dockerfile): expose port 80 in addition to port 8501